### PR TITLE
Annetaan SpringApplication.run:lle oikea luokka sekä muita pieniä korjauksia tekstiin

### DIFF
--- a/osa1.html
+++ b/osa1.html
@@ -737,7 +737,7 @@ public class ThymeleafJaDataController {
 	    
             <p>HTML-sivuille voi määritellä lomakkeita (<a href="http://www.w3schools.com/html/html_forms.asp" target="_blank">form</a>), joiden avulla käyttäjä voi lähettää tietoa palvelimelle. Lomakkeen määrittely tapahtuu <code>form</code>-elementin avulla, jolle kerrotaan polku, mihin lomake lähetetään (action), sekä pyynnön tyyppi (method). Pidämme pyynnön tyypin toistaiseksi GET-tyyppisenä.</p>
 	    
-	    <p>Lomakkeeseen voidaan määritellä mm. tekstikenttiä (<code>&lt;input type="text"...</code>) sekä painike, jolla lomake lähetetään (<code>&lt;input type="submit"...</code>). Alla tekstikentän <code>name</code>-attribuutin arvoksi on asetettu nimi. Tämä tarkoittaa sitä, että kun lomakkeen tiedot lähetetään palvelimelle, tulee pyynnössä <code>nimi</code>-niminen parametri, jonka arvona on tekstikenttään kirjoitettu teksti.</p>
+	    <p>Lomakkeeseen voidaan määritellä mm. tekstikenttiä (<code>&lt;input type="text"...</code>) sekä painike, jolla lomake lähetetään (<code>&lt;input type="submit"...</code>). Alla tekstikentän <code>name</code>-attribuutin arvoksi on asetettu <code>nimi</code>. Tämä tarkoittaa sitä, että kun lomakkeen tiedot lähetetään palvelimelle, tulee pyynnössä <code>nimi</code>-niminen parametri, jonka arvona on tekstikenttään kirjoitettu teksti.</p>
 
 <pre class="sh_xml">
 &lt;form th:action="@{/}" method="GET"&gt;

--- a/osa1.html
+++ b/osa1.html
@@ -228,7 +228,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class HeiMaailmaApplication {
 
     public static void main(String[] args) throws Exception {
-        SpringApplication.run(HeiMaailmaController.class, args);
+        SpringApplication.run(HeiMaailmaApplication.class, args);
     }
 }
 </pre>

--- a/osa1.html
+++ b/osa1.html
@@ -990,7 +990,7 @@ public class Henkilo {
 }
 </pre>
 
-	    <p>Henkilö-olion lisääminen on suoraviivaista:</p>
+	    <p>Henkilo-olion lisääminen on suoraviivaista:</p>
 
 <pre class="sh_java">
     @RequestMapping("/")
@@ -1006,7 +1006,7 @@ public class Henkilo {
 <pre class="sh_xml">
 &lt;h2 th:text="${henkilo}"&gt;Henkilön nimi&lt;/h2&gt;</pre>
 
-	    <p>Ylläolevaa Henkilön tulostusta kokeillessamme saamme näkyville (esim.) merkkijonon <code>Henkilo@29453f44</code> -- ei ihan mitä toivoimme. Käytännössä Thymeleaf kutsuu edellisessä tapauksessa olioon liittyvää <code>toString</code>-metodia, jota emme ole määritelleet. Pääsemme oliomuuttujiin käsiksi olemassaolevien <code>get<em>Muuttuja</em></code>-metodien kautta. Jos haluamme tulostaa Henkilö-olioon liittyvän nimen, kutsumme metodia <code>getNimi</code>. Thymeleafin käyttämässä notaatiossa kutsu muuntuu muotoon <code>henkilo.nimi</code>. Saamme siis halutun tulostuksen seuraavalla tavalla:</p>
+	    <p>Ylläolevaa henkilön tulostusta kokeillessamme saamme näkyville (esim.) merkkijonon <code>Henkilo@29453f44</code> -- ei ihan mitä toivoimme. Käytännössä Thymeleaf kutsuu edellisessä tapauksessa olioon liittyvää <code>toString</code>-metodia, jota emme ole määritelleet. Pääsemme oliomuuttujiin käsiksi olemassaolevien <code>get<em>Muuttuja</em></code>-metodien kautta. Jos haluamme tulostaa Henkilo-olioon liittyvän nimen, kutsumme metodia <code>getNimi</code>. Thymeleafin käyttämässä notaatiossa kutsu muuntuu muotoon <code>henkilo.nimi</code>. Saamme siis halutun tulostuksen seuraavalla tavalla:</p>
 
 <pre class="sh_xml">
 &lt;h2 th:text="${henkilo.nimi}"&gt;Henkilön nimi&lt;/h2&gt;</pre>
@@ -1057,7 +1057,7 @@ public class HenkiloController {
 &lt;p&gt;Ja huomenna puheet pitävät:&lt;/p&gt;
 &lt;ol&gt;
     &lt;li th:each="henkilo : ${list}"&gt;
-        &lt;span th:text="${henkilo.nimi}"&gt;Esimerkkihenkilo&lt;/span&gt;
+        &lt;span th:text="${henkilo.nimi}"&gt;Esimerkkihenkilö&lt;/span&gt;
     &lt;/li&gt;
 &lt;/ol&gt;
 </pre>

--- a/osa1.html
+++ b/osa1.html
@@ -859,9 +859,9 @@ public class ListaController {
 		
                 <div id="t-hellolist" class="collapse">
 		  
-		  <p>Tehtäväpohjassa on palvelinpuolen toiminnallisuus, jossa käsitellään juuripolkuun tuleva pyyntö, sekä lisätään lista Thymeleafille sivun käsittelyyn. Tehtäväpohjaan liittyvä html-sivu ei kuitenkaan sisällä juurikaan toiminnallisuutta.</p>
+		  <p>Tehtäväpohjassa on palvelinpuolen toiminnallisuus, jossa käsitellään juuripolkuun tuleva pyyntö, sekä lisätään lista Thymeleafille sivun käsittelyyn. Tehtäväpohjaan liittyvä HTML-sivu ei kuitenkaan sisällä juurikaan toiminnallisuutta.</p>
 		  
-		  <p>Lisää html-sivulla (1) listalla olevien arvojen tulostaminen <code>th:each</code>-komennon avulla ja (2) lomake, jonka avulla palvelimelle voidaan lähettää uusia arvoja.</p>
+		  <p>Lisää HTML-sivulle (1) listalla olevien arvojen tulostaminen <code>th:each</code>-komennon avulla ja (2) lomake, jonka avulla palvelimelle voidaan lähettää uusia arvoja.</p>
 		  
 		  <p>Alla on esimerkki ohjelman toiminnasta, kun sivulle on lisätty muutama rivi lomakkeen avulla. Viimeisimpänä on juuri lisätty teksti "Hello?".</p>
 		  

--- a/osa1.html
+++ b/osa1.html
@@ -790,7 +790,7 @@ public class ThymeleafJaDataController {
 	    <h2>Listojen käsittely</h2>
 
 
-	    <p>Thymeleafille annettavalle Model-oliolle voi asettaa tekstin lisäksi myös arvokokoelmia. Alla luomme "pääohjelmassa" listan, joka asetetaan Thymeleafin käsiteltäväksi menevään HashMap-olioon jokaisen juuripolkuun tehtävän pyynnön yhteydessä. Jos juuripolkuun lähetetään parametri nimeltä <code>"content"</code>, lisätään se myös listaan -- alla parametri on määritelty ei-pakolliseksi annotaation <code>@RequestMapping</code> attribuutilla <code>required = false</code>.</p>
+	    <p>Thymeleafille annettavalle Model-oliolle voi asettaa tekstin lisäksi myös arvokokoelmia. Alla luomme "pääohjelmassa" listan, joka asetetaan Thymeleafin käsiteltäväksi menevään Model-olioon jokaisen juuripolkuun tehtävän pyynnön yhteydessä. Jos juuripolkuun lähetetään parametri nimeltä <code>"content"</code>, lisätään se myös listaan -- alla parametri on määritelty ei-pakolliseksi annotaation <code>@RequestMapping</code> attribuutilla <code>required = false</code>.</p>
 
 <pre class="sh_java">
 package thymeleafdata;

--- a/osa1.html
+++ b/osa1.html
@@ -833,7 +833,7 @@ public class ListaController {
     &lt;/p&gt;
 &lt;/pre&gt;</pre>
 
-            <p>Yllä käytämme attribuuttia nimeltä <code>lista</code> ja tulostamme yksitellen sen sisältämät alkiot. Attribuutin <code>th:each</code> voi asettaa käytännössä mille tahansa toistettavalle elementille. Esimerkiksi listan voisi tehdä seuraavalla tavalla.</p>
+            <p>Yllä käytämme attribuuttia nimeltä <code>lista</code> ja tulostamme yksitellen sen sisältämät alkiot. Attribuutin <code>th:each</code> voi asettaa käytännössä mille tahansa toistettavalle elementille. Esimerkiksi HTML-listan voisi tehdä seuraavalla tavalla.</p>
 
             <pre class="sh_xml">
 &lt;ul&gt;


### PR DESCRIPTION
SpringApplication.run:lle tulee antaa SpringApplication, ei kontrolleria.

Kontrolleriluokan käytöstä aiheutuu hieman epäselvä virhe "Unable to start EmbeddedWebApplicationContext due to missing EmbeddedServletContainerFactory bean." (http://pastebin.com/Tm1EfSNY)
